### PR TITLE
[codex] tidy darwin setup commands

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -49,6 +49,7 @@
         # work
         baldrick = libx.mkDarwin { hostname = "baldrick"; };
         magrathea = libx.mkDarwin { hostname = "magrathea"; };
+        beefcake = libx.mkDarwin { hostname = "beefcake"; };
       };
 
       nixosConfigurations = {

--- a/hosts/common/darwin-common-dock.nix
+++ b/hosts/common/darwin-common-dock.nix
@@ -5,13 +5,12 @@
       "/Applications/Google Chrome.app"
       "/Applications/Firefox.app"
       "/Applications/Telegram.app"
-      "/Applications/Signal.app"
       "/Applications/Discord.app"
       "/Applications/Slack.app"
-      "/Applications/Ivory.app"
       "/Applications/Obsidian.app"
       "/Applications/Spotify.app"
       "/Applications/Visual Studio Code.app"
+      "/Applications/Codex.app"
       "/Applications/Ghostty.app"
     ];
   };

--- a/hosts/common/darwin-common.nix
+++ b/hosts/common/darwin-common.nix
@@ -3,6 +3,10 @@ let
   inherit (inputs) nixpkgs nixpkgs-unstable;
 in
 {
+  imports = [
+    ./darwin-launchd-wrappers.nix
+  ];
+
   users.users.alex.home = "/Users/alex";
 
   nix = {
@@ -77,13 +81,16 @@ in
     onActivation = {
       cleanup = "zap";
       autoUpdate = true;
-      upgrade = true;
+      # Keep activation mostly automatic, but avoid MAS update/auth failures on
+      # every switch. Keep masApps as inventory, but install them interactively.
+      upgrade = false;
+      extraEnv.HOMEBREW_BUNDLE_MAS_SKIP =
+        lib.concatStringsSep " " (map toString (builtins.attrValues config.homebrew.masApps));
     };
     global.autoUpdate = true;
 
     brews = [
       "ansible"
-      "esptool"
       "mas"
       #"bitwarden-cli"
       "neovim"
@@ -93,8 +100,6 @@ in
     ];
     taps = [
       # Keep third-party cask taps pinned so brew bundle cleanup does not try to untap them.
-      "typewhisper/tap"
-      "xykong/tap"
       #"FelixKratz/formulae" #sketchybar
     ];
     casks = [
@@ -108,19 +113,13 @@ in
       #"balenaetcher"
       "bambu-studio"
       "bentobox"
-      "claude"
       #"claude-code"
-      #"clop"
-      "chatgpt-atlas" # Atlas browser
+      "codex-app"
       "discord"
-      "displaylink"
       #"docker"
       "element"
-      "elgato-camera-hub"
       "elgato-control-center"
-      "elgato-stream-deck"
       "firefox"
-      "xykong/tap/flux-markdown"
       "font-fira-code"
       "font-fira-code-nerd-font"
       "font-fira-mono-for-powerline"
@@ -135,11 +134,9 @@ in
       "hyperkey"
       "istat-menus"
       "iterm2"
-      "jordanbaird-ice"
       "karabiner-elements"
       "linearmouse"
       "lm-studio"
-      "logitech-options"
       "macwhisper"
       #"marta"
       "mqtt-explorer"
@@ -152,7 +149,6 @@ in
       "omnidisksweeper"
       "orbstack"
       "openscad"
-      "openttd"
       "plexamp"
       "portalbox"
       #"popclip"
@@ -164,7 +160,6 @@ in
       "slack"
       "spotify"
       "steam"
-      "typewhisper/tap/typewhisper"
       #"wireshark"
       #"viscosity"
       "visual-studio-code"
@@ -188,7 +183,7 @@ in
       "Ivory for Mastodon by Tapbots" = 6444602274;
       #"Home Assistant Companion" = 1099568401;
       #"Microsoft Remote Desktop" = 1295203466;
-      "Perplexity" = 6714467650;
+      #"Perplexity" = 6714467650; # No current Mac App Store result.
       "Resize Master" = 1025306797;
       "rCmd" = 1596283165;
       "Snippety" = 1530751461;
@@ -208,9 +203,9 @@ in
       #"ShutterCount" = 720123827;
       #"Teleprompter" = 1533078079;
 
-      "Keynote" = 409183694;
-      "Numbers" = 409203825;
-      "Pages" = 409201541;
+      "Keynote" = 361285480;
+      "Numbers" = 361304891;
+      "Pages" = 361309726;
     };
   };
 

--- a/hosts/common/darwin-launchd-wrappers.nix
+++ b/hosts/common/darwin-launchd-wrappers.nix
@@ -1,0 +1,75 @@
+{ config, lib, pkgs, ... }:
+let
+  # These scripts must live outside /nix/store because launchd starts them
+  # before the encrypted Nix Store volume has necessarily been mounted.
+  wrapperDir = "/Library/Application Support/nix-darwin/launchd-wrappers";
+  wrapper = name: "${wrapperDir}/${name}";
+  quote = lib.escapeShellArg;
+
+  mountStoreWrapper = pkgs.writeText "nix-store-mounter" ''
+    #!/bin/sh
+    set -eu
+
+    if [ -d /nix/store ]; then
+      exit 0
+    fi
+
+    volume_name="''${NIX_DARWIN_STORE_VOLUME_NAME:-Nix Store}"
+    volume_uuid="$(/usr/sbin/diskutil info -plist "$volume_name" 2>/dev/null | /usr/bin/plutil -extract VolumeUUID raw -o - - 2>/dev/null || true)"
+
+    if [ -z "$volume_uuid" ]; then
+      echo "Nix Store Mounter: APFS volume '$volume_name' not found" >&2
+      exit 1
+    fi
+
+    if passphrase="$(/usr/bin/security find-generic-password -s "$volume_uuid" -w 2>/dev/null)"; then
+      printf '%s' "$passphrase" | /usr/sbin/diskutil apfs unlockVolume "$volume_uuid" -mountpoint /nix -stdinpassphrase \
+        || /usr/sbin/diskutil mount -mountPoint /nix "$volume_uuid"
+    else
+      /usr/sbin/diskutil mount -mountPoint /nix "$volume_uuid"
+    fi
+
+    /bin/wait4path /nix/store
+  '';
+
+  nixDaemonWrapper = pkgs.writeText "nix-daemon-launcher" ''
+    #!/bin/sh
+    set -eu
+
+    /bin/wait4path /nix/store
+    exec ${quote config.launchd.daemons.nix-daemon.command}
+  '';
+
+  activateSystemWrapper = pkgs.writeText "nix-darwin-activator" ''
+    #!/bin/sh
+    set -eu
+
+    /bin/wait4path /nix/store
+    exec ${quote config.launchd.daemons.activate-system.command}
+  '';
+in
+{
+  system.activationScripts.extraActivation.text = lib.mkAfter ''
+    printf >&2 'installing named nix-darwin launchd wrappers...\n'
+
+    /bin/mkdir -p ${quote wrapperDir}
+    /usr/sbin/chown root:wheel ${quote wrapperDir}
+    /bin/chmod 0755 ${quote wrapperDir}
+
+    /usr/bin/install -m 0755 -o root -g wheel ${mountStoreWrapper} ${quote (wrapper "Nix Store Mounter")}
+    /usr/bin/install -m 0755 -o root -g wheel ${nixDaemonWrapper} ${quote (wrapper "Nix Daemon")}
+    /usr/bin/install -m 0755 -o root -g wheel ${activateSystemWrapper} ${quote (wrapper "Nix Darwin Activator")}
+  '';
+
+  launchd.daemons.darwin-store = {
+    serviceConfig.Label = "org.nixos.darwin-store";
+    serviceConfig.ProgramArguments = lib.mkForce [ (wrapper "Nix Store Mounter") ];
+    serviceConfig.RunAtLoad = true;
+  };
+
+  launchd.daemons.nix-daemon.serviceConfig.ProgramArguments =
+    lib.mkForce [ (wrapper "Nix Daemon") ];
+
+  launchd.daemons.activate-system.serviceConfig.ProgramArguments =
+    lib.mkForce [ (wrapper "Nix Darwin Activator") ];
+}

--- a/hosts/darwin/baldrick/apps.nix
+++ b/hosts/darwin/baldrick/apps.nix
@@ -1,0 +1,8 @@
+{ lib, ... }:
+{
+  homebrew.casks = lib.mkAfter [
+    "displaylink"
+    "elgato-camera-hub"
+    "elgato-stream-deck"
+  ];
+}

--- a/hosts/darwin/baldrick/default.nix
+++ b/hosts/darwin/baldrick/default.nix
@@ -1,6 +1,7 @@
 { ... }:
 {
   imports = [
+    ./apps.nix
     ./custom-dock.nix
   ];
 }

--- a/justfile
+++ b/justfile
@@ -1,144 +1,43 @@
-# Build the system config and switch to it when running `just` with no args
 default: switch
 
 hostname := `hostname | cut -d "." -f 1`
 
-### macos
-# Build role. Use proxmox-template for the Proxmox VMA image; otherwise defaults to this Mac.
 [macos]
 build role=hostname flags="":
-  #!/usr/bin/env bash
-  set -euo pipefail
-  case "{{role}}" in
-    proxmox-template)
-      echo "Building proxmox-template."
-      scripts/proxmox-template/build {{flags}}
-      ;;
-    *)
-      echo "Building nix-darwin config for {{role}}."
-      nix --extra-experimental-features 'nix-command flakes' build ".#darwinConfigurations.{{role}}.system" {{flags}}
-      ;;
-  esac
+  scripts/darwin/build-system "{{role}}" {{flags}}
 
-# Build the nix-darwin config with the --show-trace flag set
 [macos]
 trace role=hostname: (build role "--show-trace")
 
-# Build the current nix-darwin configuration and switch to it
 [macos]
-switch: (build hostname)
-  @echo "switching to new config for {{hostname}}"
-  sudo ./result/sw/bin/darwin-rebuild switch --flake ".#{{hostname}}"
+switch:
+  scripts/darwin/switch-system "{{hostname}}"
 
-### linux
-# Build role. Use proxmox-template for the Proxmox VMA image; otherwise defaults to this NixOS host.
 [linux]
 build role=hostname flags="":
-  #!/usr/bin/env bash
-  set -euo pipefail
-  case "{{role}}" in
-    proxmox-template)
-      echo "Building proxmox-template (Proxmox VMA image) locally."
-      nix --extra-experimental-features 'nix-command flakes' build \
-        .#nixosConfigurations.proxmox-template.config.system.build.image {{flags}}
-      echo "OK: proxmox-template image build completed."
-      echo "Artifact output is linked at ./result."
-      ;;
-    *)
-      nixos-rebuild build --flake .#{{role}} {{flags}}
-      ;;
-  esac
+  scripts/nixos/build-system "{{role}}" {{flags}}
 
-# Build the NixOS config with the --show-trace flag set
 [linux]
 trace role=hostname: (build role "--show-trace")
 
-# Build the current NixOS configuration and switch to it.
 [linux]
 switch:
-  sudo nixos-rebuild switch --flake .#{{hostname}}
+  scripts/nixos/switch-system "{{hostname}}"
 
-## colmena
-cbuild:
-  colmena build
-
-capply:
-  colmena apply
-
-# Update flake inputs to their latest revisions
 update:
   nix flake update
 
-## CI command group. Run `just ci help` for subcommands.
 ci *ARGS:
   scripts/ci {{ARGS}}
 
-## remote nix vm installation
+mas action:
+  scripts/darwin/install-mas-apps {{action}}
+
 install IP:
-  ssh -o "StrictHostKeyChecking no" nixos@{{IP}} "sudo bash -c '\
-    nix-shell -p git --run \"cd /root/ && \
-    if [ -d \"nix-config\" ]; then \
-        rm -rf nix-config; \
-    fi && \
-    git clone https://github.com/ironicbadger/nix-config.git && \
-    cd nix-config/lib/install && \
-    sh install-nix.sh\"'"
+  scripts/nixos/install-remote-vm "{{IP}}"
 
-
-## remote nixos rebuilds
-# Run nixos-rebuild on a remote NixOS host by flake name and IP.
-# Examples:
-#   just remote switch HOST IP
-#   just remote boot HOST IP
-#   just remote switch HOST IP USER BUILD_HOST
 remote action host ip user="root" build_host="":
-  #!/usr/bin/env bash
-  set -euo pipefail
-  case "{{action}}" in
-    switch|boot) ;;
-    *)
-      echo "Unknown remote action '{{action}}'. Use 'switch' or 'boot'." >&2
-      exit 2
-      ;;
-  esac
-  if [ -n "{{build_host}}" ]; then
-    if command -v timeout >/dev/null 2>&1; then
-      timeout 60m nix run nixpkgs#nixos-rebuild -- {{action}} \
-        --flake "path:$PWD#{{host}}" \
-        --target-host "{{user}}@{{ip}}" \
-        --build-host "{{build_host}}"
-    elif command -v gtimeout >/dev/null 2>&1; then
-      gtimeout 60m nix run nixpkgs#nixos-rebuild -- {{action}} \
-        --flake "path:$PWD#{{host}}" \
-        --target-host "{{user}}@{{ip}}" \
-        --build-host "{{build_host}}"
-    else
-      echo "timeout or gtimeout is required." >&2
-      exit 2
-    fi
-  else
-    if command -v timeout >/dev/null 2>&1; then
-      timeout 60m nix run nixpkgs#nixos-rebuild -- {{action}} \
-        --flake "path:$PWD#{{host}}" \
-        --target-host "{{user}}@{{ip}}" \
-        --build-host "{{user}}@{{ip}}"
-    elif command -v gtimeout >/dev/null 2>&1; then
-      gtimeout 60m nix run nixpkgs#nixos-rebuild -- {{action}} \
-        --flake "path:$PWD#{{host}}" \
-        --target-host "{{user}}@{{ip}}" \
-        --build-host "{{user}}@{{ip}}"
-    else
-      echo "timeout or gtimeout is required." >&2
-      exit 2
-    fi
-  fi
+  scripts/nixos/remote-rebuild "{{action}}" "{{host}}" "{{ip}}" "{{user}}" "{{build_host}}"
 
-# Garbage collect old OS generations and remove stale packages from the nix store
 gc:
-  nix-collect-garbage -d
-  nix-collect-garbage --delete-older-than 7d
-  nix-store --gc
-
-## manual command for initial bootstrapping
-## sh <(curl --proto '=https' --tlsv1.2 -L https://nixos.org/nix/install)
-## nix --extra-experimental-features 'nix-command flakes' run nixpkgs#just
+  scripts/collect-garbage

--- a/scripts/collect-garbage
+++ b/scripts/collect-garbage
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+nix-collect-garbage -d
+nix-collect-garbage --delete-older-than 7d
+nix-store --gc

--- a/scripts/darwin/build-system
+++ b/scripts/darwin/build-system
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+role="${1:-}"
+shift || true
+
+if [ "$role" = "proxmox-template" ]; then
+  echo "Building proxmox-template."
+  scripts/proxmox-template/build "$@"
+else
+  echo "Building nix-darwin config for ${role}."
+  nix --extra-experimental-features 'nix-command flakes' build ".#darwinConfigurations.${role}.system" "$@"
+fi

--- a/scripts/darwin/install-mas-apps
+++ b/scripts/darwin/install-mas-apps
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  just mas install
+  just mas get
+USAGE
+}
+
+action="${1:-}"
+case "$action" in
+  install|get) ;;
+  help|-h|--help)
+    usage
+    exit 0
+    ;;
+  *)
+    echo "Unknown mas action '${action}'. Use 'install' or 'get'." >&2
+    usage >&2
+    exit 2
+    ;;
+esac
+
+host="$(hostname | cut -d "." -f 1)"
+ids="$(
+  nix --extra-experimental-features 'nix-command flakes' eval --raw \
+    ".#darwinConfigurations.${host}.config.homebrew.masApps" \
+    --apply 'apps: builtins.concatStringsSep " " (map builtins.toString (builtins.attrValues apps))'
+)"
+
+if [ -z "$ids" ]; then
+  echo "No masApps configured for ${host}."
+  exit 0
+fi
+
+installed_ids="$(mas list | awk '{print $1}')"
+missing_ids=()
+for id in $ids; do
+  if ! grep -qx "$id" <<< "$installed_ids"; then
+    missing_ids+=("$id")
+  fi
+done
+
+if [ "${#missing_ids[@]}" -eq 0 ]; then
+  echo "All configured Mac App Store apps are already installed for ${host}."
+  exit 0
+fi
+
+if [ "$action" = "get" ]; then
+  echo "Acquiring and installing missing Mac App Store apps for ${host}; App Store may ask for your password."
+else
+  echo "Installing previously acquired Mac App Store apps for ${host}."
+fi
+
+sudo -v
+failed=0
+for id in "${missing_ids[@]}"; do
+  mas "$action" "$id" || failed=1
+done
+exit "$failed"

--- a/scripts/darwin/switch-system
+++ b/scripts/darwin/switch-system
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+host="${1:-}"
+
+scripts/darwin/build-system "$host"
+echo "switching to new config for ${host}"
+sudo ./result/sw/bin/darwin-rebuild switch --flake ".#${host}"

--- a/scripts/nixos/build-system
+++ b/scripts/nixos/build-system
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+role="${1:-}"
+shift || true
+
+if [ "$role" = "proxmox-template" ]; then
+  echo "Building proxmox-template (Proxmox VMA image) locally."
+  nix --extra-experimental-features 'nix-command flakes' build \
+    .#nixosConfigurations.proxmox-template.config.system.build.image "$@"
+  echo "OK: proxmox-template image build completed."
+  echo "Artifact output is linked at ./result."
+else
+  nixos-rebuild build --flake ".#${role}" "$@"
+fi

--- a/scripts/nixos/install-remote-vm
+++ b/scripts/nixos/install-remote-vm
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ip="${1:-}"
+
+if [ -z "$ip" ]; then
+  echo "Usage: just install IP" >&2
+  exit 2
+fi
+
+ssh -o "StrictHostKeyChecking no" "nixos@${ip}" "sudo bash -c '\
+  nix-shell -p git --run \"cd /root/ && \
+  if [ -d \"nix-config\" ]; then \
+      rm -rf nix-config; \
+  fi && \
+  git clone https://github.com/ironicbadger/nix-config.git && \
+  cd nix-config/lib/install && \
+  sh install-nix.sh\"'"

--- a/scripts/nixos/remote-rebuild
+++ b/scripts/nixos/remote-rebuild
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  just remote switch HOST IP
+  just remote boot HOST IP
+  just remote switch HOST IP USER BUILD_HOST
+USAGE
+}
+
+action="${1:-}"
+host="${2:-}"
+ip="${3:-}"
+user="${4:-root}"
+build_host="${5:-}"
+
+case "$action" in
+  switch|boot) ;;
+  help|-h|--help)
+    usage
+    exit 0
+    ;;
+  *)
+    echo "Unknown remote action '${action}'. Use 'switch' or 'boot'." >&2
+    usage >&2
+    exit 2
+    ;;
+esac
+
+if [ -z "$host" ] || [ -z "$ip" ]; then
+  usage >&2
+  exit 2
+fi
+
+if command -v timeout >/dev/null 2>&1; then
+  timeout_cmd="timeout"
+elif command -v gtimeout >/dev/null 2>&1; then
+  timeout_cmd="gtimeout"
+else
+  echo "timeout or gtimeout is required." >&2
+  exit 2
+fi
+
+if [ -z "$build_host" ]; then
+  build_host="${user}@${ip}"
+fi
+
+"$timeout_cmd" 60m nix run nixpkgs#nixos-rebuild -- "$action" \
+  --flake "path:$PWD#$host" \
+  --target-host "${user}@${ip}" \
+  --build-host "$build_host"

--- a/scripts/nixos/switch-system
+++ b/scripts/nixos/switch-system
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+host="${1:-}"
+
+sudo nixos-rebuild switch --flake ".#${host}"


### PR DESCRIPTION
## Summary

- Adds the `beefcake` darwin configuration and separates Baldrick-specific casks into its own host app module.
- Adds launchd wrapper scripts for nix-darwin services that need stable paths before the Nix store is available.
- Simplifies the `justfile` into a compact command index and moves implementation details into platform-specific scripts under `scripts/darwin` and `scripts/nixos`.

## Validation

- `just --list`
- `bash -n scripts/darwin/build-system scripts/darwin/switch-system scripts/darwin/install-mas-apps scripts/nixos/build-system scripts/nixos/switch-system scripts/nixos/install-remote-vm scripts/nixos/remote-rebuild scripts/collect-garbage scripts/ci`